### PR TITLE
Schedule doesn't crash if backend isn't turned on

### DIFF
--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -94,50 +94,54 @@ export const Schedule = () => {
     >
       <Container mb={32} maxW="container.xl">
         <Heading mb={6}>View Schedule</Heading>
-        <Flex alignItems="center" justifyContent="space-between" mb={5}>
-          <Select
-            id="select"
-            w="16rem"
-            value={viewState}
-            onChange={(e) =>
-              e.target.value === "table"
-                ? setViewState(ViewTypes.table)
-                : setViewState(ViewTypes.calendar)
-            }
-          >
-            <option value="table">Table View</option>
-            <option value="calendar">Calendar View</option>
-          </Select>
-          {!scheduleLoading && (
-            <SearchBar
-              termData={baseScheduleData.courses}
-              setScheduleData={setScheduleData}
-            />
-          )}
-          <Button
-            w="300px"
-            as={Link}
-            to="/schedule"
-            backgroundColor="purple.300"
-            colorScheme="purple"
-            variant="solid"
-          >
-            Generate New Schedule
-          </Button>
-        </Flex>
-        <Flex
-          p={10}
-          borderRadius={10}
-          flexDir="column"
-          style={{ boxShadow: "0px 0px 30px rgba(0, 0, 0, 0.40)" }}
-        >
+        {!baseScheduleData || scheduleError ? (
+          <> Failed to fetch course data. Is the backend running? </>
+        ) : (
           <>
-            {viewState === ViewTypes.table && <TableView />}
-            {viewState === ViewTypes.calendar && scheduleData && (
-              <CalendarView data={scheduleData} />
-            )}
+            <Flex alignItems="center" justifyContent="space-between" mb={5}>
+              <Select
+                id="select"
+                w="16rem"
+                value={viewState}
+                onChange={(e) =>
+                  e.target.value === "table"
+                    ? setViewState(ViewTypes.table)
+                    : setViewState(ViewTypes.calendar)
+                }
+              >
+                <option value="table">Table View</option>
+                <option value="calendar">Calendar View</option>
+              </Select>
+              <SearchBar
+                termData={baseScheduleData.courses}
+                setScheduleData={setScheduleData}
+              />
+              <Button
+                w="300px"
+                as={Link}
+                to="/schedule"
+                backgroundColor="purple.300"
+                colorScheme="purple"
+                variant="solid"
+              >
+                Generate New Schedule
+              </Button>
+            </Flex>
+            <Flex
+              p={10}
+              borderRadius={10}
+              flexDir="column"
+              style={{ boxShadow: "0px 0px 30px rgba(0, 0, 0, 0.40)" }}
+            >
+              <>
+                {viewState === ViewTypes.table && <TableView />}
+                {viewState === ViewTypes.calendar && scheduleData && (
+                  <CalendarView data={scheduleData} />
+                )}
+              </>
+            </Flex>
           </>
-        </Flex>
+        )}
       </Container>
     </Flex>
   );


### PR DESCRIPTION
Just a quick fix to prevent the site from crashing when navigating to the schedule page without the backend. Now there's error text that acts as a reminder to turn the backend on.