### PR TITLE
Add inputs to generate page

### DIFF
--- a/src/pages/Generate.tsx
+++ b/src/pages/Generate.tsx
@@ -1,7 +1,33 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import { Button, Flex } from "@chakra-ui/react";
+import React, { useState } from "react";
+import {
+  Button,
+  Container,
+  Flex,
+  FormLabel,
+  Heading,
+  Input,
+  Select,
+} from "@chakra-ui/react";
+import { gql, useMutation } from "@apollo/client";
+
+const GENERATE = gql`
+  mutation GenerateSchedule($year: String!, $semester: String!) {
+    generateSchedule(year: $year, year: $semester) {
+      year
+      semester
+    }
+  }
+`;
+
 export const Generate = () => {
+  const [submit, { data, loading, error }] = useMutation(GENERATE);
+  const [year, setYear] = useState("");
+  const [term, setTerm] = useState("");
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    submit({ variables: { year, term } });
+    e.preventDefault();
+  };
   return (
     <Flex
       w="100%"
@@ -11,16 +37,55 @@ export const Generate = () => {
       justifyContent="center"
       flexDirection="column"
     >
-      <Button
-        mt={5}
-        w="300px"
-        as={Link}
-        to="/schedule"
-        colorScheme="purple"
-        variant="solid"
+      <Container
+        bg="gray.700"
+        borderRadius={20}
+        p={10}
+        style={{ boxShadow: "0px 0px 30px rgba(0, 0, 0, 0.40)" }}
+        textAlign="center"
       >
-        Generate Schedule
-      </Button>
+        <Heading mb={4}>Generate Schedule</Heading>
+        <form onSubmit={onSubmit}>
+          <FormLabel htmlFor="year">Year</FormLabel>
+          <Select
+            placeholder="Select Year"
+            value={year}
+            onChange={(e) => setYear(e.target.value)}
+            mb={5}
+            w="50%"
+          >
+            <option value="2022">2022</option>
+            <option value="2023">2023</option>
+            <option value="2024">2024</option>
+          </Select>
+          <FormLabel htmlFor="term">Term</FormLabel>
+          <Select
+            placeholder="Select Term"
+            value={term}
+            onChange={(e) => setTerm(e.target.value)}
+            mb={5}
+            w="50%"
+          >
+            <option value="Spring">Spring</option>
+            <option value="Summer">Summer</option>
+            <option value="Fall">Fall</option>
+          </Select>
+          <FormLabel htmlFor="courses">Courses</FormLabel>
+          <Input
+            id="courses"
+            placeholder="Placeholder for when adding courses ready"
+          />
+          <Button
+            mt={5}
+            w="300px"
+            colorScheme="purple"
+            variant="solid"
+            isLoading={loading}
+          >
+            Generate Schedule
+          </Button>
+        </form>
+      </Container>
     </Flex>
   );
 };

--- a/src/pages/Generate.tsx
+++ b/src/pages/Generate.tsx
@@ -11,10 +11,10 @@ import {
 import { gql, useMutation } from "@apollo/client";
 
 const GENERATE = gql`
-  mutation GenerateSchedule($year: String!, $semester: String!) {
-    generateSchedule(year: $year, year: $semester) {
+  mutation GenerateSchedule($year: String!, $term: String!) {
+    generateSchedule(year: $year, term: $term) {
       year
-      semester
+      term
     }
   }
 `;


### PR DESCRIPTION
Just added some inputs for the year and term along with a place holder for courses input. For the demo we will just be using year and term according to backend. Once backend creates the endpoint we can make sure the graphql works and add logic to redirect to schedule view page. As of now the submit button will do nothing 