### PR TITLE
Front end now queries backend for schedule

### DIFF
--- a/src/components/Schedule/CalendarView.tsx
+++ b/src/components/Schedule/CalendarView.tsx
@@ -24,28 +24,23 @@ const splitCourseDays = (course: CourseSection) => {
     const { startTime, endTime, day } = meetingTime;
 
     //2022-05-31T is a monday, and we just need the base to be a monday
-    //HH:MM:SS.000-7:00 for time format, it comes in HHMM format.
-    const beginHoursMinutes = [
-      startTime.slice(0, startTime.length / 2),
-      startTime.slice(-startTime.length / 2),
-    ];
-    const endHourMinutes = [
-      endTime.slice(0, endTime.length / 2),
-      endTime.slice(-endTime.length / 2),
-    ];
+    //HH:MM:SS.000-7:00 for time format, it comes in HHMM format
+
+    const startTimeDate = new Date(startTime);
+    const endTimeDate = new Date(endTime);
 
     const start =
       "2022-05-31T" +
-      beginHoursMinutes[0] +
+      startTimeDate.getHours() +
       ":" +
-      beginHoursMinutes[1] +
-      ":00.000-07:00";
+      startTimeDate.getMinutes() +
+      ":00.000Z";
     const end =
       "2022-05-31T" +
-      endHourMinutes[0] +
+      endTimeDate.getHours() +
       ":" +
-      endHourMinutes[1] +
-      ":00.000-07:00";
+      endTimeDate.getMinutes() +
+      ":00.000Z";
 
     const startDate = new Date(start);
     const endDate = new Date(end);
@@ -69,7 +64,7 @@ const splitCourseDays = (course: CourseSection) => {
 //convert Course object data from backend to the structure DevExtreme expects
 const buildAppointments = (courses: CourseSection[]) => {
   const appointments = courses.flatMap((course) => {
-    const professors = course.professors.map((prof) => prof.username); //TO-DO switch to displayName, when its in schema
+    //const professors = course.professors.map((prof) => prof.username); //TO-DO switch to displayName, when its in schema
 
     const assignedCourses = splitCourseDays(course).map((meetingTime) => {
       return {
@@ -77,7 +72,7 @@ const buildAppointments = (courses: CourseSection[]) => {
         courseNumber: course.CourseID.code,
         subject: course.CourseID.subject,
         section: "TEMP_SECTION", //not in schema yet
-        prof: professors,
+        prof: ["temp name"], //not in schema yet
         classSize: course.capacity,
         startDate: meetingTime.startDate,
         endDate: meetingTime.endDate,

--- a/src/components/Schedule/SearchBar.tsx
+++ b/src/components/Schedule/SearchBar.tsx
@@ -30,12 +30,12 @@ export const SearchBar = (props: SearchBarProps) => {
     const inputWords = searchInput.toLowerCase().split(" ");
     const filteredAppointments = termData.filter((course) => {
       const courseProperties = Object.values(course.CourseID);
-      const courseProfessors = course.professors.map(
-        (prof) => prof.username //TO-DO change to displayName, once it's in the schema
-      );
+      // const courseProfessors = course.professors.map(
+      //   (prof) => prof.username //TO-DO change to displayName, once it's in the schema
+      // );
 
       let appointmentValues = "";
-      [...courseProperties, ...courseProfessors].forEach(
+      [...courseProperties /*...courseProfessors*/].forEach(
         (value) => (appointmentValues += value.toLowerCase())
       );
       return inputWords.every((word) => appointmentValues.includes(word));

--- a/src/components/Schedule/TableView.tsx
+++ b/src/components/Schedule/TableView.tsx
@@ -9,6 +9,7 @@ import {
   Td,
   TableContainer,
 } from "@chakra-ui/react";
+import { formatDate, formatTime } from "../../utils/formatDate";
 
 interface TableProps {
   data: CourseSection[];
@@ -39,17 +40,19 @@ export const TableView = (props: TableProps) => {
       for (var y = 0; y < len; y++) {
         d = d + courses[i].meetingTimes[y].day.slice(0, 3) + " ";
       }
+      const startTime = new Date(courses[i].meetingTimes[0].startTime);
+      const endTime = new Date(courses[i].meetingTimes[0].endTime);
+      const startDate = new Date(courses[i].startDate);
+      const endDate = new Date(courses[i].endDate);
+
       tableData.push({
         course: courses[i].CourseID.subject + " " + courses[i].CourseID.code,
-        schedule_time:
-          courses[i].meetingTimes[0].startTime +
-          " / " +
-          courses[i].meetingTimes[0].endTime,
+        schedule_time: formatTime(startTime) + " / " + formatTime(endTime),
         days: d,
         term: courses[i].CourseID.term,
-        prof: courses[i].professors[0].username,
-        section: (i + 1).toString(),
-        start_end: courses[i].startDate + " / " + courses[i].endDate,
+        prof: "temp", //not in schema
+        section: (i + 1).toString(), //not in schema
+        start_end: formatDate(startDate) + " / " + formatDate(endDate),
         capacity: courses[i].capacity.toString(),
       });
     }

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -9,23 +9,29 @@ import { SearchBar } from "../components/Schedule/SearchBar";
 
 //TO-DO: query for a specific term (fall, spring, summer)
 const COURSES = gql`
-  query GetCourses {
-    courses {
-      CourseID {
-        subject
-        code
-        term
-      }
-      capacity
-      professors {
-        username
-      }
-      startDate
-      endDate
-      meetingTimes {
-        day
-        startTime
-        endTime
+  query s {
+    schedule(year: 2022) {
+      id
+      year
+      createdAt
+      courses(term: FALL) {
+        CourseID {
+          subject
+          code
+          term
+        }
+        hoursPerWeek
+        professors {
+          username
+        }
+        capacity
+        startDate
+        endDate
+        meetingTimes {
+          day
+          startTime
+          endTime
+        }
       }
     }
   }
@@ -48,7 +54,7 @@ export const Schedule = () => {
 
   useEffect(() => {
     if (baseScheduleData && !scheduleError && !scheduleLoading) {
-      setScheduleData(baseScheduleData.courses);
+      setScheduleData(baseScheduleData.schedule.courses);
     }
   }, [baseScheduleData, scheduleError, scheduleLoading]);
 
@@ -82,7 +88,7 @@ export const Schedule = () => {
                 <option value="calendar">Calendar View</option>
               </Select>
               <SearchBar
-                termData={baseScheduleData.courses}
+                termData={baseScheduleData.schedule.courses}
                 setScheduleData={setScheduleData}
               />
               <Button

--- a/src/stores/schedule.ts
+++ b/src/stores/schedule.ts
@@ -47,8 +47,8 @@ export type CourseID = {
 
 export type MeetingTime = {
   day: Day;
-  startTime: String; //Schema has this as Date, but shouldn't this be string??
-  endTime: String; //Schema has this as Date, but shouldn't this be string??
+  startTime: Date; //Schema has this as Date, but shouldn't this be string??
+  endTime: Date; //Schema has this as Date, but shouldn't this be string??
 };
 
 export enum Day {

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,9 @@
+export const formatTime = (date: Date) => {
+  return `${date.getHours()}:${date.getMinutes()}`;
+};
+
+export const formatDate = (date: Date) => {
+  return `${date.getDate()} ${date.toLocaleString("default", {
+    month: "long",
+  })} ${date.getFullYear()}`;
+};


### PR DESCRIPTION
Updated the GraphQL query and fixed some logic so that we now use the backends schedule. There is a lot missing here, and a lot to be improved on, but we are accurately displaying the schedules we are given.

![calendar](https://user-images.githubusercontent.com/48161540/175871891-59f0d14c-42f9-464f-ba5c-6ad79537a8c0.PNG)

