### PR TITLE
Fix the logic for filtering courses by term

### DIFF
--- a/src/pages/Generate/index.tsx
+++ b/src/pages/Generate/index.tsx
@@ -236,12 +236,16 @@ export const Generate = () => {
         const courseKeys = new Set<string>();
         const options = (courseData.survey.courses as CourseSection[])
           .filter((course) => {
-            const key = course.subject + course.code;
-            if (courseKeys.has(key)) {
-              return false;
+            if (term === "WHOLE_YEAR" || course.term === term) {
+              const key = course.subject + course.code;
+              if (courseKeys.has(key)) {
+                return false;
+              } else {
+                courseKeys.add(key);
+                return true;
+              }
             }
-            courseKeys.add(key);
-            return term === "WHOLE_YEAR" || course.term === term;
+            return false;
           })
           .map((course) => {
             return {


### PR DESCRIPTION
The logic here was causing some courses to be left out of the term that they are suppose to be shown in. Just had to re arrange the logic to check if the term is correct first, then check if the course is unique, originally it was the other way around so if there was a SENG 360 Fall that showed up before a SENG 360 Spring, SENG 360 would not be included in the spring term. 