### PR TITLE
fix date year and table width

### DIFF
--- a/src/components/Schedule/TableView.tsx
+++ b/src/components/Schedule/TableView.tsx
@@ -78,9 +78,9 @@ export const TableView = (props: TableProps) => {
               <Th>Course</Th>
               <Th>Schedule Time</Th>
               <Th>Days</Th>
-              <Th>Term</Th>
               <Th>Prof/Instructor</Th>
               <Th>Section</Th>
+              <Th>Term</Th>
               <Th>Start/End Date</Th>
               <Th>Capacity</Th>
               <Th>Edit</Th>
@@ -105,9 +105,9 @@ export const TableView = (props: TableProps) => {
                   <Td>{item.course}</Td>
                   <Td>{item.schedule_time}</Td>
                   <Td>{item.days}</Td>
-                  <Td>{item.term}</Td>
                   <Td>{item.prof}</Td>
                   <Td>{item.sectionNumber}</Td>
+                  <Td>{item.term}</Td>
                   <Td>{item.start_end}</Td>
                   <Td>{item.capacity}</Td>
                   <Td>

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
 import {
-  Button,
   Container,
   Flex,
   Select,
@@ -11,7 +10,6 @@ import {
   Text,
   FormLabel,
 } from "@chakra-ui/react";
-import { Link } from "react-router-dom";
 import { gql, useQuery } from "@apollo/client";
 import { TableView } from "../components/Schedule/TableView";
 import { CalendarView } from "../components/Schedule/CalendarView";

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -3,10 +3,19 @@ export const formatTime = (date: Date) => {
 };
 
 export const formatDate = (date: Date) => {
-  return `${date.getDate()} ${date.toLocaleString("default", {
-    month: "long",
-  })} ${date.getFullYear()}`;
+  return `${getNumberWithOrdinal(date.getDate())} ${date.toLocaleString(
+    "default",
+    {
+      month: "long",
+    }
+  )}`;
 };
+
+function getNumberWithOrdinal(n: number) {
+  const s = ["th", "st", "nd", "rd"],
+    v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
 
 export const formatTimeString = (date: Date) => {
   let hours = date.getUTCHours().toString();


### PR DESCRIPTION
Fixed two bugs here:

- Table view having a horizontal scroll bar if the contents were too long
- The year data being wrong sometimes

I fixed this by removing the year from the date column entirely, but I also moved the term column to be beside it. I think with these two columns beside eachother, and with the year displayed at the top, it gives enough context to what the dates mean.

And with the dates data being smaller the width problem is no longer an issue.