### PR TITLE
Calendar interval change

### DIFF
--- a/src/components/Schedule/CalendarView.tsx
+++ b/src/components/Schedule/CalendarView.tsx
@@ -99,7 +99,7 @@ export const CalendarView = (props: CalendarProps) => {
     }
 
     .dx-scheduler-cell-sizes-vertical {
-      height: 60px;
+      height: 30px;
     }
   `;
 
@@ -138,7 +138,7 @@ export const CalendarView = (props: CalendarProps) => {
         showAllDayPanel={false}
         startDayHour={8}
         endDayHour={20}
-        cellDuration={60}
+        cellDuration={30}
         textExpr="courseTitle"
         onAppointmentDblClick={(e) => (e.cancel = true)}
         startDateExpr={"startTime"}


### PR DESCRIPTION
Just a quick change that adjust the calendar interval gaps to 30 minutes from an hour. The calendar looks basically the same but now you can drag courses to 30 minute intervals